### PR TITLE
[breaking-change] Yield settings in configure

### DIFF
--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -53,7 +53,7 @@ describe Habitat do
     FakeServer.settings.this_can_be_nil.should eq "not nil"
 
     FakeServer.settings.nilable_with_default.should eq "default"
-    FakeServer.configure { settings.nilable_with_default = nil }
+    FakeServer.configure { |settings| settings.nilable_with_default = nil }
     FakeServer.settings.nilable_with_default.should be_nil
   end
 
@@ -76,7 +76,7 @@ describe Habitat do
       Habitat.raise_if_missing_settings!
     end
 
-    FakeServer.configure do
+    FakeServer.configure do |settings|
       settings.this_is_missing = "Not anymore"
     end
 
@@ -87,7 +87,7 @@ end
 private def setup_server(port = 8080,
                          something_that_can_be_multiple_types = "string type",
                          this_can_be_nil = nil)
-  FakeServer.configure do
+  FakeServer.configure do |settings|
     settings.port = port
     settings.something_that_can_be_multiple_types = something_that_can_be_multiple_types
     settings.this_can_be_nil = this_can_be_nil

--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -17,16 +17,6 @@ class FakeServer
 end
 
 describe Habitat do
-  context ".configure" do
-    it "passes settings as yield argument" do
-      setup_server
-      FakeServer.configure do |config|
-        config.port = 8080
-      end
-      FakeServer.settings.port.should eq(8080)
-    end
-  end
-
   it "works with simple types" do
     setup_server(port: 8080)
 

--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -17,6 +17,16 @@ class FakeServer
 end
 
 describe Habitat do
+  context ".configure" do
+    it "passes settings as yield argument" do
+      setup_server
+      FakeServer.configure do |config|
+        config.port = 8080
+      end
+      FakeServer.settings.port.should eq(8080)
+    end
+  end
+
   it "works with simple types" do
     setup_server(port: 8080)
 

--- a/src/habitat.cr
+++ b/src/habitat.cr
@@ -42,7 +42,7 @@ class Habitat
     REQUIRED_SETTINGS = [] of TypeDeclaration
 
     def self.configure
-      with self yield settings
+      yield settings
     end
 
     class Settings

--- a/src/habitat.cr
+++ b/src/habitat.cr
@@ -42,7 +42,7 @@ class Habitat
     REQUIRED_SETTINGS = [] of TypeDeclaration
 
     def self.configure
-      with self yield
+      with self yield settings
     end
 
     class Settings


### PR DESCRIPTION
Changes how `#configure` yields given block, from `with self yield` to `yield settings`.

Before:

```cr
Klass.configure do
  settings.option = "value"
end
```

Now:

```cr
Klass.configure do |settings|
  settings.option = "value"
end
```