### PR TITLE
Inherit setting values from base class

### DIFF
--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -19,6 +19,7 @@ end
 class Parent
   Habitat.create do
     setting parent_setting : Bool = true
+    setting inheritable_setting : String = ""
   end
 end
 
@@ -55,11 +56,20 @@ describe Habitat do
   end
 
   it "works with inherited config" do
-    Parent.settings.parent_setting.should be_true
-    Child.settings.parent_setting.should be_true
-    Child.settings.is_child.should be_true
-    AnotherChild.settings.parent_setting.should be_true
-    AnotherChild.settings.responds_to?(:another_one).should be_false
+    Parent.temp_config(inheritable_setting: "inherit me") do
+      Parent.settings.parent_setting.should be_true
+      Child.settings.parent_setting.should be_true
+      Child.settings.inheritable_setting.should eq "inherit me"
+      Child.settings.is_child.should be_true
+      AnotherChild.settings.parent_setting.should be_true
+      AnotherChild.settings.responds_to?(:another_one).should be_false
+    end
+
+    Child.configure do
+      settings.another_one = "another"
+    end
+
+    Child.settings.another_one.should eq "another"
   end
 
   it "works with union types" do

--- a/src/habitat.cr
+++ b/src/habitat.cr
@@ -62,7 +62,7 @@ class Habitat
 
     {{ yield }}
 
-    inherit_habitat_settings_from_superclass
+    # inherit_habitat_settings_from_superclass
 
     macro finished
       Habitat.create_settings_methods(\{{ @type }})
@@ -84,8 +84,17 @@ class Habitat
   end
 
   macro create_settings_methods(type_with_habitat)
+    {% type_with_habitat = type_with_habitat.resolve %}
+
     class Settings
-      {% type_with_habitat = type_with_habitat.resolve %}
+      {% if type_with_habitat.superclass && type_with_habitat.superclass.constant(:HABITAT_SETTINGS) %}
+        {% for decl in type_with_habitat.superclass.constant(:HABITAT_SETTINGS) %}
+          def self.{{ decl.var }}
+            ::{{ type_with_habitat.superclass }}::Settings.{{ decl.var }}
+          end
+        {% end %}
+      {% end %}
+
       {% for decl in type_with_habitat.constant(:HABITAT_SETTINGS) %}
         {% if decl.type.is_a?(Union) && decl.type.types.map(&.id).includes?(Nil.id) %}
           {% nilable = true %}


### PR DESCRIPTION
Doesn't inherit setters though. That's because I think that could get
confusing. If you want to have different setters for different classes,
then redeclare the setting to make it clear.

This may be annoying, but I'd like to start simple and see if it
actually is.