### PR TITLE
Renamed Settings to HabitatSettings. 

### DIFF
--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -47,6 +47,11 @@ end
 class AnotherChild < Parent
 end
 
+# Test that using the constant name Settings doesn't actually conflict with
+# the HabitatSettings class
+class Settings::Index < Parent
+end
+
 describe Habitat do
   it "works with simple types" do
     setup_server(port: 8080)
@@ -147,6 +152,10 @@ describe Habitat do
       "nilable_with_default"                 => nil,
     }
     FakeServer.settings.to_h.should eq hash
+  end
+
+  it "doesn't conflict with Habitat Settings" do
+    Settings::Index.settings.parent_setting.should eq true
   end
 end
 

--- a/src/habitat.cr
+++ b/src/habitat.cr
@@ -136,15 +136,15 @@ class Habitat
       yield settings
     end
 
-    class Settings
+    class HabitatSettings
     end
 
     def self.settings
-      Settings
+      HabitatSettings
     end
 
     def settings
-      Settings
+      HabitatSettings
     end
 
     {{ yield }}
@@ -175,11 +175,11 @@ class Habitat
   macro create_settings_methods(type_with_habitat)
     {% type_with_habitat = type_with_habitat.resolve %}
 
-    class Settings
+    class HabitatSettings
       {% if type_with_habitat.superclass && type_with_habitat.superclass.type_vars.size == 0 && type_with_habitat.superclass.constant(:HABITAT_SETTINGS) %}
         {% for decl in type_with_habitat.superclass.constant(:HABITAT_SETTINGS).map { |setting| setting[:decl] } %}
           def self.{{ decl.var }}
-            ::{{ type_with_habitat.superclass }}::Settings.{{ decl.var }}
+            ::{{ type_with_habitat.superclass }}::HabitatSettings.{{ decl.var }}
           end
         {% end %}
       {% end %}


### PR DESCRIPTION
Fixes #45

I first tried to use a private class to do this, but it was throwing errors, so I decided to just rename it. I don't think that class is ever really called outside of this shard anyway.