### PR TITLE
Add new validation feature for settings. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,24 @@ class MyServer
     # Use `String#dump` when you want the example to be wrapped in quotes
     setting host : String, example: "127.0.0.1".dump
     setting logger : Logger, example: "Logger.new(STDOUT)"
+
+    # If you need the value to match a specific format, you can create
+    # your own validation.
+    setting protocol : String, validation: :validate_protocol
   end
 
-  # Access them like this
+  # Read more on validations below
+  def self.validate_protocol(value : String)
+    value.match(/^http(?:s)*:$/) || Habitat.raise_validation_error("The protocol must be `http:` or `https:`.")
+  end
+
+  # Access them with the `settings` method like this.
   def start
     start_server_on port: settings.port
   end
 end
 
+# Configure your settings
 MyServer.configure do |settings|
   settings.port = 8080
 end
@@ -52,6 +62,41 @@ Settings can also be accessed from outside the class:
 ```crystal
 port = MyServer.settings.port
 puts "The server is starting on port #{port}"
+```
+
+### Setting validations
+
+The `validation` option takes a Symbol which matches a class method
+that will run your custom validation. This can be useful if your
+setting needs to be in a specific format like maybe a 4 digit code
+that can start with a 0.
+
+```crystal
+class Secret
+  Habitat.create do
+    setting code : String, validation: :validate_code
+  end
+
+  # The validation method will take an argument of the same type.
+  # If your setting is `Int32`, then this argument will also be `Int32`.
+  #
+  # Use any method of validation you'd like here. (i.e. regex, other custom methods, etc...)
+  # If your validation fails, you can call `Habitat.raise_validation_error` with your custom error
+  # message
+  def self.validate_code(value : String)
+    value.match(/^\d{4}$/) || Habitat.raise_validation_error("Be sure the code is only 4 digits")
+  end
+end
+
+Secret.configure do |settings|
+
+  # Even though the code is the correct type, this will still
+  # raise an error for us. 
+  settings.code = "ABCD"
+
+  # This value will pass our validation
+  settings.code = "0123"
+end
 ```
 
 ## Contributing

--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -44,11 +44,11 @@ class WithSpecialFormat
   end
 
   def self.pin_format(value : String)
-    value.match(/^\d{4}$/) || settings.invalid("Number must be exactly 4 digits")
+    value.match(/^\d{4}$/) || Habitat.raise_validation_error("Number must be exactly 4 digits")
   end
 
   def self.code_format(value : Int32)
-    (value > 99 && value < 199) || settings.invalid("Number must between 99 and 199")
+    (value > 99 && value < 199) || Habitat.raise_validation_error("Number must between 99 and 199")
   end
 end
 

--- a/src/habitat.cr
+++ b/src/habitat.cr
@@ -65,6 +65,11 @@ class Habitat
     end
   end
 
+  # Raise the `message` passed in.
+  def self.raise_validation_error(message : String)
+    raise InvalidSettingFormatError.new(message)
+  end
+
   # Embed settings in a Class or Module.
   #
   # A class or module can call `Habitat.create` with a block of `setting` calls
@@ -139,7 +144,7 @@ class Habitat
   #   end
   #
   #   def self.pin_format(value : String)
-  #     value.match(/^\d{4}/) || settings.invalid("Your PIN must be exactly 4 digits")
+  #     value.match(/^\d{4}/) || Habitat.raise_validation_error("Your PIN must be exactly 4 digits")
   #   end
   # end
   # ```
@@ -220,11 +225,6 @@ class Habitat
 
         {% has_default = decl.value || decl.value == false %}
         @@{{ decl.var }} : {{decl.type}} | Nil {% if has_default %} = {{ decl.value }}{% end %}
-
-        # Raise the `message` passed in.
-        def self.invalid(message : String)
-          raise ::Habitat::InvalidSettingFormatError.new(message)
-        end
 
         def self.{{ decl.var }}=(value : {{ decl.type }})
           {% if opt[:validation] %}

--- a/src/habitat.cr
+++ b/src/habitat.cr
@@ -18,6 +18,10 @@ class Habitat
     end
   end
 
+  # :nodoc:
+  class InvalidSettingFormatError < Exception
+  end
+
   TYPES_WITH_HABITAT = [] of Nil
 
   # :nodoc:
@@ -124,6 +128,28 @@ class Habitat
   #   settings.port = "80" # Compile-time error! An Int32 was expected
   # end
   # ```
+  #
+  # Each setting can take an optional `validation` argument to ensure the setting
+  # value matches a specific format.
+  #
+  # ```
+  # class MyMachine
+  #   Habitat.create do
+  #     setting pin : String, validation: :pin_format
+  #   end
+  #
+  #   def self.pin_format(value : String)
+  #     value.match(/^\d{4}/) || settings.invalid("Your PIN must be exactly 4 digits")
+  #   end
+  # end
+  # ```
+  #
+  # Even though the type is correct, this will now raise an error because the format doesn't match
+  # ```
+  # MyMachine.configure do |settings|
+  #   settings.pin = "abcd"
+  # end
+  # ```
   macro create
     Habitat.track(\{{ @type }})
 
@@ -158,8 +184,8 @@ class Habitat
 
   # :nodoc:
   module SettingsHelpers
-    macro setting(decl, example = nil)
-      {% HABITAT_SETTINGS << {decl: decl, example: example} %}
+    macro setting(decl, example = nil, validation = nil)
+      {% HABITAT_SETTINGS << {decl: decl, example: example, validation: validation} %}
     end
 
     macro inherit_habitat_settings_from_superclass
@@ -184,7 +210,8 @@ class Habitat
         {% end %}
       {% end %}
 
-      {% for decl in type_with_habitat.constant(:HABITAT_SETTINGS).map(&.[:decl]) %}
+      {% for opt in type_with_habitat.constant(:HABITAT_SETTINGS) %}
+        {% decl = opt[:decl] %}
         {% if decl.type.is_a?(Union) && decl.type.types.map(&.id).includes?(Nil.id) %}
           {% nilable = true %}
         {% else %}
@@ -194,7 +221,15 @@ class Habitat
         {% has_default = decl.value || decl.value == false %}
         @@{{ decl.var }} : {{decl.type}} | Nil {% if has_default %} = {{ decl.value }}{% end %}
 
+        # Raise the `message` passed in.
+        def self.invalid(message : String)
+          raise ::Habitat::InvalidSettingFormatError.new(message)
+        end
+
         def self.{{ decl.var }}=(value : {{ decl.type }})
+          {% if opt[:validation] %}
+          {{ type_with_habitat }}.{{ opt[:validation].id }}(value)
+          {% end %}
           @@{{ decl.var }} = value
         end
 


### PR DESCRIPTION
Fixes #41

This adds in a new feature that lets us add some validation beyond just the existence of a value to our settings. When you add the `validation` key, you specify a symbol of the method that will run the validation. This will take an argument of the type you specified in your setting. 

Inside that method, you can run any sort of validation you wish. If that validation fails, you can call `settings.invalid()` with a message to be raised. This will raise an `InvalidSettingFormatError` with your message.