### PR TITLE
Catch when a default value raises an exception

### DIFF
--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -52,6 +52,19 @@ end
 class Settings::Index < Parent
 end
 
+# Test that when we set the default value to a setting, and the value
+class ConfigWithDefaultException
+  # Uncomment this to see a MissingSettingError
+  # Ref: https://github.com/luckyframework/habitat/issues/46
+  # Habitat.create do
+  #  setting explode : String = ConfigWithDefaultException.blows_up
+  # end
+
+  def self.blows_up
+    nil || raise "Boom"
+  end
+end
+
 describe Habitat do
   it "works with simple types" do
     setup_server(port: 8080)

--- a/src/habitat.cr
+++ b/src/habitat.cr
@@ -192,7 +192,14 @@ class Habitat
         {% end %}
 
         {% has_default = decl.value || decl.value == false %}
-        @@{{ decl.var }} : {{decl.type}} | Nil {% if has_default %} = {{ decl.value }}{% end %}
+        @@{{ decl.var }} : {{decl.type}} | Nil {% if has_default %} = begin
+          {{ decl.value }}
+        rescue
+          # This will cause a MissingSettingError to be raised
+          nil
+        end
+        {% end %}
+        
 
         def self.{{ decl.var }}=(value : {{ decl.type }})
           @@{{ decl.var }} = value

--- a/src/habitat.cr
+++ b/src/habitat.cr
@@ -192,6 +192,9 @@ class Habitat
         {% end %}
 
         {% has_default = decl.value || decl.value == false %}
+
+        # Use `begin` to catch if the default value raises an exception,
+        # then raise a MissingSettingError
         @@{{ decl.var }} : {{decl.type}} | Nil {% if has_default %} = begin
           {{ decl.value }}
         rescue


### PR DESCRIPTION
Fixes #46

If you set a setting default value to some method you may have written, and that method could raise an exception at some point, then you'll get a weird unexpected error about some recursion stuff. With this PR, we just rescue any possible exceptions, and return `nil`. This will cause Habitat to raise a `MissingSettingError` which tells you which setting failed. 