### PR TITLE
Features/extend config

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,5 +10,5 @@ license: MIT
 
 development_dependencies:
   ameba:
-    github: veelenga/ameba
-    version: ~> 0.13
+    github: crystal-ameba/ameba
+    version: 0.13.4

--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -80,6 +80,20 @@ class ConfigWithDefaultException
   end
 end
 
+class BaseConfig
+  # Comment this block out to see compile-time error
+  # from extend
+  Habitat.create do
+    setting name : String
+  end
+end
+
+class BaseConfig # reopen for extension
+  Habitat.extend do
+    setting number : Int32
+  end
+end
+
 describe Habitat do
   it "works with simple types" do
     setup_server(port: 8080)
@@ -114,6 +128,18 @@ describe Habitat do
           settings.code = 42
         end
       end
+    end
+  end
+
+  describe "extending configs" do
+    it "adds the extended setting" do
+      BaseConfig.configure do |settings|
+        settings.name = "TestConfig"
+        settings.number = 4
+      end
+
+      BaseConfig.settings.name.should eq "TestConfig"
+      BaseConfig.settings.number.should eq 4
     end
   end
 

--- a/src/habitat.cr
+++ b/src/habitat.cr
@@ -187,6 +187,31 @@ class Habitat
     end
   end
 
+  macro extend
+    macro validate_create_setup_first(type)
+      \{% if !type.has_constant? "HABITAT_SETTINGS" %}
+        \{% raise <<-ERROR
+          No create block was specified for #{type}.
+          Habitat must be created before you can extend it.
+
+          Example:
+            Habitat.create do
+              setting id : Int64
+              ...
+            end
+          ERROR
+        %}
+      \{% end %}
+    end
+
+    validate_create_setup_first(\{{ @type }})
+
+    include Habitat::TempConfig
+    include Habitat::SettingsHelpers
+
+    {{ yield }}
+  end
+
   # :nodoc:
   module SettingsHelpers
     macro setting(decl, example = nil, validation = nil)


### PR DESCRIPTION
The idea of this is coming from something I'm thinking about for Breeze. I decided to just give this a shot, but let me know if you think this is either A) a bad idea, or B) not necessary because there's a better way to handle this...

Basically, imagine you're using [Breeze](https://github.com/luckyframework/breeze), and you want to use an extension. You have this breeze config file in your Lucky app at `config/breeze.cr` that looks like this:

```crystal
Breeze.configure do |settings|
  settings.database = AppDatabase
  settings.enabled = Lucky::Env.development?
end
```

In this case, you've met all of the required settings, and Habitat is happy. Now, a few days later you decide that you want to add Carbon back in to your app, and add in the Breeze extension that requires you to configure some carbon stuff. There's now a new required setting that wasn't required before.

```crystal
Breeze.configure do |settings|
  settings.database = AppDatabase
  settings.enabled = Lucky::Env.development?

  # this is a new setting
  settings.mailer_preview_class = Emails::Previews
end
```

How this would work is Breeze sets up its Habitat config like this:

```crystal
# src/breeze.cr
module Breeze
  VERSION = "0.1.0"

  Habitat.create do
    setting database : Avram::Database.class, example: "AppDatabase"
    setting enabled : Bool, example: "Lucky::Env.development?"
  end
end
```

Then you add `require "breeze"` and get those configs. A separate file that you require `require "breeze/extensions/carbon"` might look like this:

```crystal
# src/extensions/carbon.cr
module Breeze
  Habitat.extend do
    setting mailer_preview_class : Carbon::MailerPreview.class, example: "Emails::Previews"
  end
end
```

So you still have the safety of Habitat where if you required this extension, but didn't set that `mailer_preview_class`, it would fail at compile-time. The main thing is that you'd have to reopen the class or module that originally set the config. If you try to extend on a class/module that hadn't been setup at first, then you'd get a compile-time error telling you that it needed to be configured first.:

<img width="694" alt="Screen Shot 2021-03-05 at 3 22 57 PM" src="https://user-images.githubusercontent.com/2391/110185240-adee3c00-7dc6-11eb-8302-f8f4d87f1d05.png">
