### PR TITLE
Adding spec coverage to test #37

### DIFF
--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -1,5 +1,8 @@
 require "./spec_helper"
 
+class RandomClass
+end
+
 class FakeServer
   Habitat.create do
     setting port : Int32
@@ -10,6 +13,7 @@ class FakeServer
     setting something_that_can_be_multiple_types : String | Int32
     setting this_can_be_nil : String?
     setting nilable_with_default : String? = "default"
+    setting constant_setting : RandomClass.class | Nil, example: "RandomClass"
   end
 
   def available_in_instance_methods
@@ -230,6 +234,7 @@ describe Habitat do
       "something_that_can_be_multiple_types" => "string type",
       "this_can_be_nil"                      => nil,
       "nilable_with_default"                 => nil,
+      "constant_setting"                     => RandomClass,
     }
     FakeServer.settings.to_h.should eq hash
   end
@@ -246,5 +251,6 @@ private def setup_server(port = 8080,
     settings.port = port
     settings.something_that_can_be_multiple_types = something_that_can_be_multiple_types
     settings.this_can_be_nil = this_can_be_nil
+    settings.constant_setting = RandomClass
   end
 end

--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -13,11 +13,16 @@ class FakeServer
     setting something_that_can_be_multiple_types : String | Int32
     setting this_can_be_nil : String?
     setting nilable_with_default : String? = "default"
-    setting constant_setting : RandomClass.class | Nil, example: "RandomClass"
   end
 
   def available_in_instance_methods
     settings.port
+  end
+end
+
+class SettingWithConstant
+  Habitat.create do
+    setting constant_setting : RandomClass.class, example: "RandomClass"
   end
 end
 
@@ -219,6 +224,12 @@ describe Habitat do
 
     FakeServer.configure(&.this_is_missing_and_has_example = "No longer missing")
 
+    expect_raises(Habitat::MissingSettingError, %(settings.constant_setting = RandomClass)) do
+      Habitat.raise_if_missing_settings!
+    end
+
+    SettingWithConstant.configure(&.constant_setting = RandomClass)
+
     # Should not raise now that settings are set
     Habitat.raise_if_missing_settings!
   end
@@ -234,7 +245,6 @@ describe Habitat do
       "something_that_can_be_multiple_types" => "string type",
       "this_can_be_nil"                      => nil,
       "nilable_with_default"                 => nil,
-      "constant_setting"                     => RandomClass,
     }
     FakeServer.settings.to_h.should eq hash
   end
@@ -251,6 +261,5 @@ private def setup_server(port = 8080,
     settings.port = port
     settings.something_that_can_be_multiple_types = something_that_can_be_multiple_types
     settings.this_can_be_nil = this_can_be_nil
-    settings.constant_setting = RandomClass
   end
 end


### PR DESCRIPTION
Closes #37

This is just spec coverage that proves you can use a class constant as a value in habitat. The constant can be optional, and use the `example` option.