### PR TITLE
Lock to Crystal 1.4 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
-          - 1.3.0
+          - latest
         experimental:
           - false
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{matrix.crystal_version}}
@@ -36,10 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
-          - 1.3.0
+          - 1.4.0
+          - latest
         experimental:
           - false
     runs-on: ubuntu-latest

--- a/shard.yml
+++ b/shard.yml
@@ -4,11 +4,11 @@ version: 0.4.7
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
 
-crystal: '>= 1.0.0'
+crystal: '>= 1.4.0'
 
 license: MIT
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: 0.13.4
+    version: ~> 1.0.0

--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -228,7 +228,7 @@ describe Habitat do
     FakeServer.settings.this_can_be_nil.should eq "not nil"
 
     FakeServer.settings.nilable_with_default.should eq "default"
-    FakeServer.configure { |settings| settings.nilable_with_default = nil }
+    FakeServer.configure(&.nilable_with_default = nil)
     FakeServer.settings.nilable_with_default.should be_nil
   end
 


### PR DESCRIPTION
# Purpose

Locks Lucky to Crystal version 1.4.0 or later.
# Description

With the release of the new Crystal book being focused on 1.4.0, and shards like Ameba locking to that version, as well as Crystal 1.5.0 is slated to come out in the next 2 months, it makes sense that we start pushing to have everyone use a later version of Crystal. This will also allow us to clean up some code with the assumption that the user is using 1.4.0 or later.
