### PR TITLE
fixing up the docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,14 +8,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.0.0
+          crystal: latest
       - name: "Install shards"
-        run: shards install
+        run: shards install --skip-postinstall --skip-executables
       - name: "Generate docs"
         run: crystal docs
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
This was failing because of the old Crystal version. Also, I don't think we need ameba on this, so I think we can skip the postinstall stuff...