### PR TITLE
Fixes Crystal 1.13 regression issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         crystal_version: [latest]
+        experimental: false
         include:
           - os: ubuntu-latest
             crystal_version: 1.4.0
+            experimental: false
           - os: ubuntu-latest
             crystal_version: nightly
             experimental: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,11 @@ jobs:
         include:
           - os: ubuntu-latest
             crystal_version: 1.4.0
+          - os: ubuntu-latest
+            crystal_version: nightly
+            experimental: true
     runs-on: ${{ matrix.os }}
-    continue-on-error: false
+    continue-on-error: ${{ matrix.experimental }}
     steps:
       - uses: actions/checkout@v3
       - uses: crystal-lang/install-crystal@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         crystal_version: [latest]
-        experimental: false
+        experimental: [false]
         include:
           - os: ubuntu-latest
             crystal_version: 1.4.0

--- a/src/habitat.cr
+++ b/src/habitat.cr
@@ -31,10 +31,17 @@ class Habitat
     # Habitat.raise_if_missing_settings!
     # ```
     def self.raise_if_missing_settings!
+      {% # https://github.com/crystal-lang/crystal/pull/14490
+
+ if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0
+   nil_type_id = "::Nil".id
+ else
+   nil_type_id = "Nil".id
+ end %}
       {% for type in TYPES_WITH_HABITAT %}
         {% for setting in type.constant(:HABITAT_SETTINGS) %}
         {% if !setting[:decl].type.is_a?(Union) ||
-                (setting[:decl].type.is_a?(Union) && !setting[:decl].type.types.map(&.id).includes?(Nil.id)) %}
+                (setting[:decl].type.is_a?(Union) && !setting[:decl].type.types.map(&.id).includes?(nil_type_id)) %}
             if {{ type }}.settings.{{ setting[:decl].var }}?.nil?
               raise MissingSettingError.new {{ type }}, setting_name: {{ setting[:decl].var.stringify }}, example: {{ setting[:example] }}
             end
@@ -226,12 +233,19 @@ class Habitat
         {% end %}
       {% end %}
 
+      {% # https://github.com/crystal-lang/crystal/pull/14490
+ if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0
+   nil_type_id = "::Nil".id
+ else
+   nil_type_id = "Nil".id
+ end %}
+
       {% for opt in type_with_habitat.constant(:HABITAT_SETTINGS) %}
         {% decl = opt[:decl] %}
         # NOTE: We can't use the macro level `type.resolve.nilable?` here because
         # there's a few declaration types that don't respond to it which would make the logic
         # more complex. Metaclass, and Proc types are the main, but there may be more.
-        {% if decl.type.is_a?(Union) && decl.type.types.map(&.id).includes?(Nil.id) %}
+        {% if decl.type.is_a?(Union) && decl.type.types.map(&.id).includes?(nil_type_id) %}
           {% nilable = true %}
         {% else %}
           {% nilable = false %}


### PR DESCRIPTION
Fixes #88

See comments in #88 for a more in-depth context.

TL;DR We used to use `Nil.id` to check for nilable types, but the next Crystal release 1.13 will require `"::Nil".id`

/cc @straight-shoota