### PR TITLE
Add a catch for Nilable ProcNotations.

### DIFF
--- a/spec/habitat_spec.cr
+++ b/spec/habitat_spec.cr
@@ -141,7 +141,7 @@ end
 class ASettingForEverything
   alias Dot = Int32
   Habitat.create do
-    setting proc_notation : String -> Nil
+    setting proc_notation : (String -> Nil)?
     setting alias_setting : Dot = 3
     setting point : Point = Point.new(x: 3, y: 4)
     setting mod : SuperMod

--- a/src/habitat.cr
+++ b/src/habitat.cr
@@ -34,7 +34,7 @@ class Habitat
       {% for type in TYPES_WITH_HABITAT %}
         {% for setting in type.constant(:HABITAT_SETTINGS) %}
         {% if !setting[:decl].type.is_a?(Union) ||
-                (setting[:decl].type.is_a?(Union) && !setting[:decl].type.types.any?(&.names.includes?(Nil.id))) %}
+                (setting[:decl].type.is_a?(Union) && !setting[:decl].type.types.any? { |t| t.is_a?(ProcNotation) ? false : t.names.includes?(Nil.id) }) %}
             if {{ type }}.settings.{{ setting[:decl].var }}?.nil?
               raise MissingSettingError.new {{ type }}, setting_name: {{ setting[:decl].var.stringify }}, example: {{ setting[:example] }}
             end
@@ -231,7 +231,7 @@ class Habitat
         # NOTE: We can't use the macro level `type.resolve.nilable?` here because
         # there's a few declaration types that don't respond to it which would make the logic
         # more complex. Metaclass, and Proc types are the main, but there may be more.
-        {% if decl.type.is_a?(Union) && decl.type.types.any?(&.names.includes?(Nil.id)) %}
+        {% if decl.type.is_a?(Union) && decl.type.types.any? { |t| t.is_a?(ProcNotation) ? false : t.names.includes?(Nil.id) } %}
           {% nilable = true %}
         {% else %}
           {% nilable = false %}


### PR DESCRIPTION
Fixes #90

Apparently `ProcNotation` doesn't have a `names` method in macro land, so if it's a `ProcNotation`, just return `false` since we know that specific thing will never return "Nil"